### PR TITLE
Version updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get install -y \
         containerd.io=$CONTAINERD_VERSION
 
 # install nodejs
-RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y \
         nodejs \
         autoconf \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/sdk:3.1.100
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.301
 
 # Dockerfile meta-information
 LABEL maintainer="NOS Inovação S.A." \
@@ -6,8 +6,8 @@ LABEL maintainer="NOS Inovação S.A." \
 
 # Reviewing this choices
 ENV SONAR_SCANNER_MSBUILD_VERSION=4.8.0.12008 \
-    DOTNETCORE_SDK=3.1.100 \
-    DOTNETCORE_RUNTIME=3.1.0 \
+    DOTNETCORE_SDK=3.1.301 \
+    DOTNETCORE_RUNTIME=3.1.5 \
     DOCKER_VERSION=5:19.03.2~3-0~debian-buster \
     CONTAINERD_VERSION=1.2.6-3
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="NOS Inovação S.A." \
     app_name="dotnet-sonar"
 
 # Reviewing this choices
-ENV SONAR_SCANNER_MSBUILD_VERSION=4.8.0.12008 \
+ENV SONAR_SCANNER_MSBUILD_VERSION=4.10.0.19059 \
     DOTNETCORE_SDK=3.1.301 \
     DOTNETCORE_RUNTIME=3.1.5 \
     DOCKER_VERSION=5:19.03.2~3-0~debian-buster \


### PR DESCRIPTION
there are new versions available for:

- baseimage
- dotnet core runtime
- sonarscanner

NodeJs 11 is not supported any more so I updated it to 14 but perhaps it's better to use 12 as it is a LTS version.