### PR TITLE
Set locale to UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,13 @@ RUN apt-get update \
 
 RUN mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1
 
+# Set locale to UTF-8
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+ENV LC_ALL en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+
 # Install Java
 RUN apt-get install -y openjdk-$OPENJDK_VERSION-jre
 


### PR DESCRIPTION
Sonar scanner fails when branch names contains characters like Æ, Ø or Å.

`java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters:`

Currently there is no locale set on image, this PR sets the locale to UTF-8