### PR TITLE
update: updated dotnet 10 image and README file + added support for Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0.315
+FROM mcr.microsoft.com/dotnet/sdk:10.0.301
 
 # Dockerfile meta-information
 LABEL maintainer="NOS Inovação S.A." \
     app_name="dotnet-sonar"
 
 ENV SONAR_SCANNER_MSBUILD_VERSION=11.2.1.137242 \
-    DOTNETCORE_SDK=9.0.315 \
-    DOTNETCORE_RUNTIME=9.0.17 \
+    DOTNETCORE_SDK=10.0.301 \
+    DOTNETCORE_RUNTIME=10.0.9 \
     NETAPP_VERSION=net \
-    DOCKER_VERSION=5:24.0.7-1~debian.12~bookworm \
-    CONTAINERD_VERSION=1.6.25-1 \
+    DOCKER_VERSION=5:28.5.2-1~ubuntu.24.04~noble \
+    CONTAINERD_VERSION=1.7.29-1~ubuntu.24.04~noble \
     OPENJDK_VERSION=21 \
     NODEJS_VERSION=20
-
-# Add Adoptium (Eclipse Temurin) repository for OpenJDK 21
-RUN wget -O - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc > /dev/null \
-    && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb bookworm main" | tee /etc/apt/sources.list.d/adoptium.list > /dev/null
 
 # Linux update
 RUN apt-get update \
@@ -42,7 +38,7 @@ ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 
 # Install Java
-RUN apt-get install -y temurin-$OPENJDK_VERSION-jre
+RUN apt-get install -y openjdk-$OPENJDK_VERSION-jre
 
 # Install NodeJs
 RUN wget https://deb.nodesource.com/setup_$NODEJS_VERSION.x \
@@ -51,9 +47,9 @@ RUN wget https://deb.nodesource.com/setup_$NODEJS_VERSION.x \
 
 # Install all necessary additional software
 RUN mkdir -p /etc/apt/keyrings \
-    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
     && echo \
-        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
         $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
     && apt-get update \
     && apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ It also allows you to run Docker in Docker using a docker.sock mount.
 
 This latest image was built with the following components:
 
-* dotnetcore-sdk 9.0.315
-* dotnetcore-runtime 9.0.17 (required by Sonar-Scanner)
+* dotnetcore-sdk 10.0.301
+* dotnetcore-runtime 10.0.9 (required by Sonar-Scanner)
 * SonarQube MSBuild Scanner 11.2.1.137242
 * Docker binaries 24.0.x (for running Docker in Docker using the docker.sock mount)
 * OpenJDK Java Runtime 21 (required by Sonar-Scanner and some Sonar-Scanner plugins)
@@ -24,8 +24,8 @@ This latest image was built with the following components:
 
 > Tags are written using the following pattern: `dotnet-sonar:<year>.<month>.<revision>`
 
-* `26.04.7`, `latest10`, `26.04-dotnet10`, `latest` [(26.04.7/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/26.04.7/Dockerfile)
-  * DotNet 10.0.202
+* `26.06.7`, `latest10`, `26.06-dotnet10`, `latest` [(26.06.7/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/26.06.7/Dockerfile)
+  * DotNet 10.0.301
   * SonarScanner 11.2.1.137242
 * `26.06.6`, `latest9`, `26.06-dotnet9` [(26.06.6/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/26.06.6/Dockerfile)
   * DotNet 9.0.315
@@ -45,6 +45,7 @@ This latest image was built with the following components:
 * `22.07.1`, `latest5` [(22.07.1/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/22.07.1/Dockerfile)
   * DotNet 5.0.408
   * SonarScanner 5.7.1.49528
+* `26.04.7` [(26.04.7/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/26.04.7/Dockerfile)
 * `26.04.6` [(26.04.6/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/26.04.6/Dockerfile)
 * `26.04.5` [(26.04.5/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/26.04.5/Dockerfile)
 * `25.11.7` [(25.11.7/Dockerfile)](https://github.com/nosinovacao/dotnet-sonar/blob/25.11.7/Dockerfile)


### PR DESCRIPTION
Dependency and base image upgrades:

* Updated the Docker base image from `dotnet/sdk:9.0.315` to `dotnet/sdk:10.0.301`, and upgraded related environment variables for .NET SDK and runtime to version 10.0.x.
* Changed Docker and containerd installation to use Ubuntu 24.04 (noble) repositories and updated their versions, moving away from Debian/bookworm sources. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-L19) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L54-R52)
* Switched Java installation from `temurin-21-jre` (Adoptium repository) to the standard `openjdk-21-jre` package.

Documentation updates:

* Updated the `README.md` to reflect the new .NET 10.0.301 and runtime 10.0.9 versions, and to reference the new Docker image tags and component versions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L16-R17) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R28)
* Added a missing image tag entry for `26.04.7` in the list of available image tags in the documentation.